### PR TITLE
AdHoc request improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ for requesting and waiting for data. This script can be called using `docker exe
 docker exec -it ooo_dev_env /root/xfund-router/request.sh <BASE> <TARGET> <TYPE> [SUBTYPE] [SUPP1] [SUPP2]
 ```
 
-For example:
+For example querying Finchains tracked data:
 
 ```bash
 docker exec -it ooo_dev_env /root/xfund-router/request.sh BTC GBP PR AVC 1H
@@ -169,6 +169,12 @@ docker exec -it ooo_dev_env /root/xfund-router/request.sh BTC GBP PR AVC 1H
 
 This will request data using the OoO endpoint `BTC.GBP.PR.AVC.1H`, which is the mean GBP price of Bitcoin for the
 past hour, using the Chauvenet Criterion to remove statistical outliers.
+
+Or and Ad-Hoc request:
+
+```bash
+docker exec -it ooo_dev_env /root/xfund-router/request.sh BONE WETH AD
+```
 
 See the [OoO API Guide](docs/guide/ooo_api.md) for more information on endpoint construction.
 

--- a/go-ooo/cmd/init.go
+++ b/go-ooo/cmd/init.go
@@ -109,6 +109,7 @@ Examples:
 			viper.SetDefault(config.SubChainEthHttpRpc, "")
 			viper.SetDefault(config.SubChainPolygonHttpRpc, "")
 			viper.SetDefault(config.SubChainBcsHttpRpc, "")
+			viper.SetDefault(config.SubChainXdaiHttpRpc, "")
 
 			err = viper.SafeWriteConfigAs(viper.ConfigFileUsed())
 			if err != nil {

--- a/go-ooo/cmd/init.go
+++ b/go-ooo/cmd/init.go
@@ -106,6 +106,10 @@ Examples:
 
 			viper.SetDefault(config.LogLevel, "info")
 
+			viper.SetDefault(config.SubChainEthHttpRpc, "")
+			viper.SetDefault(config.SubChainPolygonHttpRpc, "")
+			viper.SetDefault(config.SubChainBcsHttpRpc, "")
+
 			err = viper.SafeWriteConfigAs(viper.ConfigFileUsed())
 			if err != nil {
 				panic(err)

--- a/go-ooo/config/constants.go
+++ b/go-ooo/config/constants.go
@@ -29,3 +29,12 @@ const DatabaseDatabase = "database.database"
 const PrometheusPort = "prometheus.port"
 
 const LogLevel = "log.level"
+
+// SubChainEthHttpRpc only used to get the latest block number
+const SubChainEthHttpRpc = "subchain.eth_http_rpc"
+
+// SubChainPolygonHttpRpc only used to get the latest block number
+const SubChainPolygonHttpRpc = "subchain.polygon_http_rpc"
+
+// SubChainBcsHttpRpc only used to get the latest block number
+const SubChainBcsHttpRpc = "subchain.bsc_http_rpc"

--- a/go-ooo/config/constants.go
+++ b/go-ooo/config/constants.go
@@ -38,3 +38,5 @@ const SubChainPolygonHttpRpc = "subchain.polygon_http_rpc"
 
 // SubChainBcsHttpRpc only used to get the latest block number
 const SubChainBcsHttpRpc = "subchain.bsc_http_rpc"
+
+const SubChainXdaiHttpRpc = "subchain.xdai_http_rpc"

--- a/go-ooo/database/database.go
+++ b/go-ooo/database/database.go
@@ -73,6 +73,7 @@ func NewPostgresDb(logger logger.Interface) (*DB, error) {
 }
 
 func (d *DB) Migrate() (err error) {
+	// migrate models
 	err = d.AutoMigrate(
 		&models.DataRequests{},
 		&models.FailedFulfilment{},
@@ -80,7 +81,12 @@ func (d *DB) Migrate() (err error) {
 		&models.SupportedPairs{},
 		&models.DexTokens{},
 		&models.DexPairs{},
-		&models.TokenContracts{})
+		&models.TokenContracts{},
+		&models.VersionInfo{},
+	)
+
+	// post-model data migration
+	d.MigrateV0ToV1()
 
 	return
 }

--- a/go-ooo/database/migrations.go
+++ b/go-ooo/database/migrations.go
@@ -1,0 +1,22 @@
+package database
+
+/*
+  Migrations
+*/
+
+// Schema V0 to V1
+
+func (d *DB) MigrateV0ToV1() {
+	dbVers, _ := d.getCurrentDbSchemaVersion()
+	if dbVers.CurrentVersion == 0 {
+		d.V0ToV1DeleteAdhocTokenData()
+		_ = d.setDbSchemaVersion(1)
+	}
+}
+
+// V0ToV1DeleteAdhocTokenData is used when migrating from Db v0 to v1
+func (d *DB) V0ToV1DeleteAdhocTokenData() {
+	d.Exec("DELETE FROM dex_pairs")
+	d.Exec("DELETE FROM dex_tokens")
+	d.Exec("DELETE FROM token_contracts")
+}

--- a/go-ooo/database/models/dex_pairs.go
+++ b/go-ooo/database/models/dex_pairs.go
@@ -8,11 +8,12 @@ type DexPairs struct {
 	gorm.Model
 	DexName         string `gorm:"index:idx_dex_pair;index:idx_dex_pair_dex_name"`
 	Pair            string `gorm:"index:idx_dex_pair;index:idx_dex_pair_pair"`
-	T0              string `gorm:"index"`
-	T1              string `gorm:"index"`
+	T0DexTokenId    uint   `gorm:"index:idx_dex_pair_t0;index:idx_dex_pair_t0_t1"`
+	T1DexTokenId    uint   `gorm:"index:idx_dex_pair_t1;index:idx_dex_pair_t0_t1"`
+	T0Symbol        string `gorm:"index"`
+	T1Symbol        string `gorm:"index"`
 	ContractAddress string `gorm:"index"`
-	HasPair         bool   `gorm:"index:idx_checked_has_pair;index:idx_has_pair"`
-	LastCheckDate   uint64 `gorm:"index:idx_checked_has_pair;index:idx_pair_last_check_date"`
+	ReserveUsd      float64
 }
 
 func (DexPairs) TableName() string {
@@ -27,22 +28,14 @@ func (d *DexPairs) GetPair() string {
 	return d.Pair
 }
 
-func (d *DexPairs) GetBase() string {
-	return d.T0
+func (d *DexPairs) GetT0DexTokenId() uint {
+	return d.T0DexTokenId
 }
 
-func (d *DexPairs) GetTarget() string {
-	return d.T1
+func (d *DexPairs) GetT1DexTokenId() uint {
+	return d.T1DexTokenId
 }
 
 func (d *DexPairs) GetContractAddress() string {
 	return d.ContractAddress
-}
-
-func (d *DexPairs) GetHasPair() bool {
-	return d.HasPair
-}
-
-func (d *DexPairs) GetLastCheckDate() uint64 {
-	return d.LastCheckDate
 }

--- a/go-ooo/database/models/dex_tokens.go
+++ b/go-ooo/database/models/dex_tokens.go
@@ -4,10 +4,10 @@ import "gorm.io/gorm"
 
 type DexTokens struct {
 	gorm.Model
-	DexName          string `gorm:"index:idx_dex_tokens_token_symbol;index:idx_dex_tokens_name"`
+	DexName          string `gorm:"index:idx_dex_tokens_token_symbol;index:idx_dex_tokens_name;index:idx_dex_tokens_dex_chain"`
 	TokenSymbol      string `gorm:"index:idx_dex_tokens_token_symbol;index:idx_dex_tokens_symbol"`
 	TokenContractsId uint   `gorm:"index:idx_dex_tokens_tokenid_check_date;index:idx_dex_tokens_tokenid"`
-	LastCheckDate    uint64 `gorm:"index:idx_dex_tokens_tokenid_check_date"`
+	Chain            string `gorm:"index:idx_dex_tokens_chain;index:idx_dex_tokens_dex_chain"`
 }
 
 func (DexTokens) TableName() string {
@@ -22,6 +22,6 @@ func (d *DexTokens) GetTokenContractsId() uint {
 	return d.TokenContractsId
 }
 
-func (d *DexTokens) GetLastCheckDate() uint64 {
-	return d.LastCheckDate
+func (d *DexTokens) GetChain() string {
+	return d.Chain
 }

--- a/go-ooo/database/models/version_info.go
+++ b/go-ooo/database/models/version_info.go
@@ -1,0 +1,27 @@
+package models
+
+import "gorm.io/gorm"
+
+const VERSION_TYPE_DB_SCHEMA = "db_schema"
+
+type VersionInfo struct {
+	gorm.Model
+	VersionType    string
+	CurrentVersion uint64
+}
+
+func (VersionInfo) TableName() string {
+	return "version_info"
+}
+
+func (d VersionInfo) GetId() uint {
+	return d.ID
+}
+
+func (d VersionInfo) GetVersionType() string {
+	return d.VersionType
+}
+
+func (d VersionInfo) GetCurrentVersion() uint64 {
+	return d.CurrentVersion
+}

--- a/go-ooo/database/queries.go
+++ b/go-ooo/database/queries.go
@@ -91,7 +91,9 @@ func (d *DB) FindByDexPairName(base string, target string, dexName string) (mode
 	pair := fmt.Sprintf("%s-%s", base, target)
 	pairRev := fmt.Sprintf("%s-%s", target, base)
 	result := models.DexPairs{}
-	err := d.Where("(pair = ? OR pair = ?) AND dex_name = ?", pair, pairRev, dexName).First(&result).Error
+	err := d.Where(
+		"(pair = ? OR pair = ?) AND dex_name = ?", pair, pairRev, dexName,
+	).Order("reserve_usd desc").First(&result).Error
 	return result, err
 }
 

--- a/go-ooo/database/queries.go
+++ b/go-ooo/database/queries.go
@@ -105,6 +105,12 @@ func (d *DB) FindByDexTokenSymbol(symbol string, dexName string) (models.DexToke
 	return result, err
 }
 
+func (d *DB) FindByDexTokenAll(symbol string, dexName string, tokenContractsId uint) (models.DexTokens, error) {
+	result := models.DexTokens{}
+	err := d.Where("token_symbol = ? AND dex_name = ? AND token_contracts_id = ?", symbol, dexName, tokenContractsId).First(&result).Error
+	return result, err
+}
+
 /*
   TokenContracts queries
 */
@@ -115,8 +121,24 @@ func (d *DB) FindByTokenAndAddress(symbol string, address string) (models.TokenC
 	return result, err
 }
 
+func (d *DB) FindByTokenAll(symbol string, address string, chain string) (models.TokenContracts, error) {
+	result := models.TokenContracts{}
+	err := d.Where("token_symbol = ? AND contract_address = ? AND chain = ?", symbol, address, chain).First(&result).Error
+	return result, err
+}
+
 func (d *DB) FindTokenAddressByRowId(id uint) (string, error) {
 	result := models.TokenContracts{}
 	err := d.Where("id = ?", id).First(&result).Error
 	return result.ContractAddress, err
+}
+
+/*
+ VersionInfo queries
+*/
+
+func (d *DB) getCurrentDbSchemaVersion() (models.VersionInfo, error) {
+	result := models.VersionInfo{}
+	err := d.Where("version_type = ?", models.VERSION_TYPE_DB_SCHEMA).First(&result).Error
+	return result, err
 }

--- a/go-ooo/go.mod
+++ b/go-ooo/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.12 // indirect
 	github.com/labstack/echo/v4 v4.6.1 // indirect
 	github.com/miguelmota/go-solidity-sha3 v0.1.1 // indirect
+	github.com/montanaflynn/stats v0.6.6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect

--- a/go-ooo/go.sum
+++ b/go-ooo/go.sum
@@ -680,6 +680,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae h1:VeRdUYdCw49yizlSbMEn2SZ+gT+3IUKx8BqxyQdz+BY=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/go-ooo/ooo_api/adhoc.go
+++ b/go-ooo/ooo_api/adhoc.go
@@ -17,11 +17,11 @@ import (
 
 // MinLiquidity ToDo - make configurable in config.toml
 // MinLiquidity - min liquidity a pair should have for the DEX pair search
-const MinLiquidity = 50000
+const MinLiquidity = 30000
 
 // MinTxCount ToDo - make configurable in config.toml
 // MinTxCount - min tx count a pair should have for the DEX pair search
-const MinTxCount = 500
+const MinTxCount = 250
 
 // currently supported DEXs for ad-hoc queries
 func getQlApis() []map[string]string {
@@ -98,6 +98,18 @@ func getQlApis() []map[string]string {
 			"chain":             "bsc",
 			"blocks_in_one_min": "20",
 		},
+		{
+			"name":              "honeyswap",
+			"url":               "https://api.thegraph.com/subgraphs/name/1hive/honeyswap-xdai",
+			"pairs_endpoint":    "pairs",
+			"pair_endpoint":     "pair",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "txCount",
+			"pairs_order_by":    "reserveUSD",
+			"tx_count":          "txCount",
+			"chain":             "xdai",
+			"blocks_in_one_min": "12",
+		},
 	}
 }
 
@@ -128,6 +140,8 @@ func (o *OOOApi) getCurrentBlockNumForChain(chain string) (uint64, error) {
 		return o.subchainPolygonClient.BlockNumber(o.ctx)
 	case "bsc":
 		return o.subchainBscClient.BlockNumber(o.ctx)
+	case "xdai":
+		return o.subchainXdaiClient.BlockNumber(o.ctx)
 	}
 
 	return 0, nil

--- a/go-ooo/ooo_api/adhoc.go
+++ b/go-ooo/ooo_api/adhoc.go
@@ -10,109 +10,220 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net/http"
-	"time"
+	"strconv"
 )
 
-const MIN_LIQUIDITY = 100000
-
-type GraphQlToken struct {
-	Id             string `json:"id,omitempty"`
-	Name           string `json:"name,omitempty"`
-	Symbol         string `json:"symbol,omitempty"`
-	TotalLiquidity string `json:"totalLiquidity,omitempty"`
-	TxCount        string `json:"txCount,omitempty"`
-}
-type GraphQlTokens struct {
-	Tokens []GraphQlToken
-}
-type GraphQlTokenResponse struct {
-	Data GraphQlTokens
-}
-
-type GraphQlPairContent struct {
-	Id                  string
-	Token0              GraphQlToken
-	Token1              GraphQlToken
-	Token0Price         string `json:"token0Price"`
-	Token1Price         string `json:"token1Price"`
-	ReserveUSD          string `json:"reserveUSD,omitempty"`
-	TotalValueLockedUSD string `json:"totalValueLockedUSD,omitempty"`
-}
-
-type GraphQlPairs struct {
-	Pairs []GraphQlPairContent `json:"pairs,omitempty"`
-	Pools []GraphQlPairContent `json:"pools,omitempty"`
-}
-type GraphQlPairsResponse struct {
-	Data GraphQlPairs
-}
-
-type GraphQlPair struct {
-	Pair GraphQlPairContent `json:"pair,omitempty"`
-	Pool GraphQlPairContent `json:"pool,omitempty"`
-}
-type GraphQlPairResponse struct {
-	Data GraphQlPair
-}
+const MIN_LIQUIDITY = 50000
+const MIN_TX_COUNT = 500
 
 // currently supported DEXs for ad-hoc queries
 func getQlApis() []map[string]string {
 	return []map[string]string{
 		{
-			"name":            "shibaswap",
-			"url":             "https://api.thegraph.com/subgraphs/name/shibaswaparmy/exchange",
-			"pairs_endpoint":  "pairs",
-			"pair_endpoint":   "pair",
-			"tokens_endpoint": "tokens",
-			"token_order_by":  "txCount",
-			"pairs_order_by":  "reserveUSD",
-			"chain":           "eth",
+			"name":              "shibaswap",
+			"url":               "https://api.thegraph.com/subgraphs/name/shibaswaparmy/exchange",
+			"pairs_endpoint":    "pairs",
+			"pair_endpoint":     "pair",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "txCount",
+			"pairs_order_by":    "reserveUSD",
+			"tx_count":          "txCount",
+			"chain":             "eth",
+			"blocks_in_one_min": "5",
 		},
 		{
-			"name":            "sushiswap",
-			"url":             "https://api.thegraph.com/subgraphs/name/sushiswap/exchange",
-			"pairs_endpoint":  "pairs",
-			"pair_endpoint":   "pair",
-			"tokens_endpoint": "tokens",
-			"token_order_by":  "txCount",
-			"pairs_order_by":  "reserveUSD",
-			"chain":           "eth",
+			"name":              "sushiswap",
+			"url":               "https://api.thegraph.com/subgraphs/name/sushiswap/exchange",
+			"pairs_endpoint":    "pairs",
+			"pair_endpoint":     "pair",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "txCount",
+			"pairs_order_by":    "reserveUSD",
+			"tx_count":          "txCount",
+			"chain":             "eth",
+			"blocks_in_one_min": "5",
 		},
 		{
-			"name":            "uniswapv2",
-			"url":             "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
-			"pairs_endpoint":  "pairs",
-			"pair_endpoint":   "pair",
-			"tokens_endpoint": "tokens",
-			"token_order_by":  "txCount",
-			"pairs_order_by":  "reserveUSD",
-			"chain":           "eth",
+			"name":              "uniswapv2",
+			"url":               "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v2",
+			"pairs_endpoint":    "pairs",
+			"pair_endpoint":     "pair",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "txCount",
+			"pairs_order_by":    "reserveUSD",
+			"tx_count":          "txCount",
+			"chain":             "eth",
+			"blocks_in_one_min": "5",
 		},
 		{
-			"name":            "uniswapv3",
-			"url":             "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3",
-			"pairs_endpoint":  "pools",
-			"pair_endpoint":   "pool",
-			"tokens_endpoint": "tokens",
-			"token_order_by":  "txCount",
-			"pairs_order_by":  "totalValueLockedUSD",
-			"chain":           "eth",
+			"name":              "uniswapv3",
+			"url":               "https://api.thegraph.com/subgraphs/name/uniswap/uniswap-v3",
+			"pairs_endpoint":    "pools",
+			"pair_endpoint":     "pool",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "txCount",
+			"pairs_order_by":    "totalValueLockedUSD",
+			"tx_count":          "txCount",
+			"chain":             "eth",
+			"blocks_in_one_min": "5",
 		},
 		{
-			"name":            "quickswap",
-			"url":             "https://api.thegraph.com/subgraphs/name/sameepsi/quickswap05",
-			"pairs_endpoint":  "pairs",
-			"pair_endpoint":   "pair",
-			"tokens_endpoint": "tokens",
-			"token_order_by":  "tradeVolumeUSD",
-			"pairs_order_by":  "reserveUSD",
-			"chain":           "matic",
+			"name":              "quickswap",
+			"url":               "https://api.thegraph.com/subgraphs/name/sameepsi/quickswap05",
+			"pairs_endpoint":    "pairs",
+			"pair_endpoint":     "pair",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "tradeVolumeUSD",
+			"pairs_order_by":    "reserveUSD",
+			"tx_count":          "",
+			"chain":             "polygon",
+			"blocks_in_one_min": "20",
 		},
+		{
+			"name":              "pancakeswap",
+			"url":               "https://api.bscgraph.org/subgraphs/name/cakeswap",
+			"pairs_endpoint":    "pairs",
+			"pair_endpoint":     "pair",
+			"tokens_endpoint":   "tokens",
+			"token_order_by":    "tradeVolumeUSD",
+			"pairs_order_by":    "reserveUSD",
+			"tx_count":          "txCount",
+			"chain":             "bsc",
+			"blocks_in_one_min": "20",
+		},
+	}
+}
+
+func getChains() []string {
+	qlApiUrls := getQlApis()
+	var chains []string
+
+	for _, a := range qlApiUrls {
+		contains := false
+		for _, c := range chains {
+			if a["chain"] == c {
+				contains = true
+			}
+		}
+		if !contains {
+			chains = append(chains, a["chain"])
+		}
+	}
+
+	return chains
+}
+
+func (o *OOOApi) getCurrentBlockNumForChain(chain string) (uint64, error) {
+	switch chain {
+	case "eth":
+		return o.subchainEthClient.BlockNumber(o.ctx)
+	case "polygon":
+		return o.subchainPolygonClient.BlockNumber(o.ctx)
+	case "bsc":
+		return o.subchainBscClient.BlockNumber(o.ctx)
+	}
+
+	return 0, nil
+}
+
+func (o *OOOApi) UpdateDexTokensAndPairs() {
+	o.logger.WithFields(logrus.Fields{
+		"package":  "ooo_api",
+		"function": "UpdateDexTokensAndPairs",
+	}).Info("begin update popular tokens")
+
+	qlApiUrls := getQlApis()
+
+	for _, api := range qlApiUrls {
+		o.updateAllTokensAndPairs(api)
+	}
+}
+
+func (o *OOOApi) updateAllTokensAndPairs(api map[string]string) {
+
+	pairs := o.getPairsFromGraphQl(api, 0)
+
+	o.logger.WithFields(logrus.Fields{
+		"package":   "ooo_api",
+		"function":  "updateAllTokensAndPairs",
+		"dex":       api["name"],
+		"num_pairs": len(pairs),
+	}).Info("found pairs")
+
+	o.updatePairsInDb(pairs, api["name"], api["chain"])
+
+	skip := uint64(1000)
+
+	for len(pairs) == 1000 {
+		o.logger.WithFields(logrus.Fields{
+			"package":  "ooo_api",
+			"function": "updateAllTokensAndPairs",
+			"dex":      api["name"],
+		}).Info("pairs > 1000. Get next pairs")
+
+		pairs = o.getPairsFromGraphQl(api, skip)
+		skip += 1000
+
+		o.logger.WithFields(logrus.Fields{
+			"package":   "ooo_api",
+			"function":  "updateAllTokensAndPairs",
+			"dex":       api["name"],
+			"num_pairs": len(pairs),
+		}).Info("found more pairs")
+
+		o.updatePairsInDb(pairs, api["name"], api["chain"])
+	}
+}
+
+func (o *OOOApi) getPairsFromGraphQl(api map[string]string, skip uint64) []GraphQlPairContent {
+	query := generatePairsListQuery(api["pairs_endpoint"], api["pairs_order_by"], api["tx_count"], skip)
+
+	var decodedResponse GraphQlPairsResponse
+
+	o.runQuery(query, api["url"], &decodedResponse)
+
+	pairs := decodedResponse.Data.Pairs
+	if api["name"] == "uniswapv3" {
+		pairs = decodedResponse.Data.Pools
+	}
+
+	return pairs
+}
+
+func (o *OOOApi) updatePairsInDb(pairs []GraphQlPairContent, dex, chain string) {
+	for _, pair := range pairs {
+		// pair.Token0.Id is the token's contract address
+		t0Db, _ := o.db.FindOrInsertNewTokenContract(pair.Token0.Symbol, pair.Token0.Id, chain)
+		t1Db, _ := o.db.FindOrInsertNewTokenContract(pair.Token1.Symbol, pair.Token1.Id, chain)
+
+		t0DtDb, _ := o.db.FindOrInsertNewDexToken(pair.Token0.Symbol, t0Db.ID, dex, chain)
+		t1DtDb, _ := o.db.FindOrInsertNewDexToken(pair.Token1.Symbol, t1Db.ID, dex, chain)
+
+		dexReserveUSD := pair.ReserveUSD
+		// todo - betterize
+		if dex == "uniswapv3" {
+			dexReserveUSD = pair.TotalValueLockedUSD
+		}
+
+		// store liquidity
+		reserve, _ := utils.ParseBigFloat(dexReserveUSD)
+		reserveUsd, _ := reserve.Float64()
+
+		// todo - update latest liquidity
+		_, _ = o.db.FindOrInsertNewDexPair(pair.Token0.Symbol, pair.Token1.Symbol, pair.Id, dex, t0DtDb.ID, t1DtDb.ID, reserveUsd)
 	}
 }
 
 func (o *OOOApi) QueryAdhoc(endpoint string, requestId string) (string, error) {
 	qlApiUrls := getQlApis()
+
+	currentBlocks := make(map[string]uint64)
+	for _, api := range qlApiUrls {
+		if _, ok := currentBlocks[api["chain"]]; !ok {
+			currentBlock, _ := o.getCurrentBlockNumForChain(api["chain"])
+			currentBlocks[api["chain"]] = currentBlock
+		}
+	}
 
 	base, target, _, _, _, _, _, err := ParseEndpoint(endpoint)
 
@@ -124,14 +235,24 @@ func (o *OOOApi) QueryAdhoc(endpoint string, requestId string) (string, error) {
 	total := big.NewInt(0)
 
 	for _, a := range qlApiUrls {
-		price := o.getPrice(base, target, a)
-		if price != "" {
-			p, e := utils.ParseBigFloat(price)
-			if e == nil {
-				wei := utils.EtherToWei(p)
-				if wei.Cmp(big.NewInt(0)) > 0 {
-					total = new(big.Int).Add(total, wei)
-					priceCount++
+		prices := o.getPairPricesFromDex(base, target, a, currentBlocks[a["chain"]])
+		for _, price := range prices {
+			if price != "" {
+				o.logger.WithFields(logrus.Fields{
+					"package":  "ooo_api",
+					"function": "QueryAdhoc",
+					"dex":      a["name"],
+					"base":     base,
+					"target":   target,
+					"price":    price,
+				}).Info("found pairs")
+				p, e := utils.ParseBigFloat(price)
+				if e == nil {
+					wei := utils.EtherToWei(p)
+					if wei.Cmp(big.NewInt(0)) > 0 {
+						total = new(big.Int).Add(total, wei)
+						priceCount++
+					}
 				}
 			}
 		}
@@ -149,7 +270,7 @@ func (o *OOOApi) QueryAdhoc(endpoint string, requestId string) (string, error) {
 func (o *OOOApi) processPriceData(base string, target string, dexName string, pair GraphQlPairContent) string {
 	price := ""
 
-	// check reserve USD and reject if < $100,000
+	// check reserve USD and reject if < MIN_LIQUIDITY
 	dexRes := pair.ReserveUSD
 	// todo - betterize
 	if dexName == "uniswapv3" {
@@ -195,181 +316,72 @@ func (o *OOOApi) processPriceData(base string, target string, dexName string, pa
 	return price
 }
 
-func (o *OOOApi) getPrice(base string, target string, api map[string]string) string {
+func (o *OOOApi) getPairPricesFromDex(base string, target string, api map[string]string, currentBlock uint64) []string {
 
-	hasData := false
-	price := ""
-	var pair GraphQlPairContent
+	var prices []string
 	// check DB for pair contract address
+	// Todo - improve. Order by liquidity descending and get top one (may be more than one pair with same token symbols)
 	dbPairRes, _ := o.db.FindByDexPairName(base, target, api["name"])
-	if dbPairRes.ID != 0 && dbPairRes.HasPair {
-		// pair address is known for this dex. Query directly
-		pair = o.getKnownPairPrice(dbPairRes.ContractAddress, api)
-		price = o.processPriceData(base, target, api["name"], pair)
-		hasData = true
+
+	if dbPairRes.ID != 0 {
+		pairPricesRes := o.getRecentPairPrices(dbPairRes.ContractAddress, api, currentBlock)
+		price0 := o.processPriceData(base, target, api["name"], pairPricesRes.P0)
+		prices = append(prices, price0)
+		price1 := o.processPriceData(base, target, api["name"], pairPricesRes.P1)
+		prices = append(prices, price1)
+		price2 := o.processPriceData(base, target, api["name"], pairPricesRes.P2)
+		prices = append(prices, price2)
+		price3 := o.processPriceData(base, target, api["name"], pairPricesRes.P3)
+		prices = append(prices, price3)
+		price4 := o.processPriceData(base, target, api["name"], pairPricesRes.P4)
+		prices = append(prices, price4)
+		price5 := o.processPriceData(base, target, api["name"], pairPricesRes.P5)
+		prices = append(prices, price5)
+		price6 := o.processPriceData(base, target, api["name"], pairPricesRes.P6)
+		prices = append(prices, price6)
+		price7 := o.processPriceData(base, target, api["name"], pairPricesRes.P7)
+		prices = append(prices, price7)
+		price8 := o.processPriceData(base, target, api["name"], pairPricesRes.P8)
+		prices = append(prices, price8)
+		price9 := o.processPriceData(base, target, api["name"], pairPricesRes.P9)
+		prices = append(prices, price9)
 	} else {
-		// only run if there's currently no entry in the DB
-		// otherwise skip, and let the crawler try to update
-		// pair data
-		// todo - implement timed crawler...
-		// todo - clean up and put in its own function
-		if dbPairRes.ID == 0 || (dbPairRes.LastCheckDate > 0 && uint64(time.Now().Unix())-dbPairRes.LastCheckDate > 3600) {
-			t0 := ""
-			t1 := ""
-			// check db for tokens
-			dbT0Res, _ := o.db.FindByDexTokenSymbol(base, api["name"])
-			if dbT0Res.ID != 0 && dbT0Res.TokenContractsId != 0 {
-				t0, _ = o.db.FindTokenAddressByRowId(dbT0Res.TokenContractsId)
-			} else {
-				t0 = o.getToken(api, base)
-				// record in DB
-				if t0 != "" {
-					t0Id, _ := o.db.FindOrInsertNewTokenContract(base, t0, api["chain"])
-					_ = o.db.UpdateOrInsertNewDexToken(base, t0Id.ID, api["name"])
-				}
-			}
-			dbT1Res, _ := o.db.FindByDexTokenSymbol(target, api["name"])
-			if dbT1Res.ID != 0 && dbT1Res.TokenContractsId != 0 {
-				t1, _ = o.db.FindTokenAddressByRowId(dbT1Res.TokenContractsId)
-			} else {
-				t1 = o.getToken(api, target)
-				// record in DB
-				if t1 != "" {
-					t1Id, _ := o.db.FindOrInsertNewTokenContract(target, t1, api["chain"])
-					_ = o.db.UpdateOrInsertNewDexToken(target, t1Id.ID, api["name"])
-				}
-			}
-			if t0 != "" && t1 != "" {
-				pair, hasData = o.getNewPairPrice(t0, t1, base, target, api)
-				// record in DB
-				if hasData {
-					_ = o.db.UpdateOrInsertNewDexPair(pair.Token0.Symbol, pair.Token1.Symbol, pair.Id, api["name"])
-				} else {
-					_ = o.db.UpdateOrInsertNewDexPair(base, target, "", api["name"])
-				}
-
-				price = o.processPriceData(base, target, api["name"], pair)
-			}
-		}
-	}
-
-	if hasData {
-		o.logger.WithFields(logrus.Fields{
-			"package":       "ooo_api",
-			"function":      "getNewPairPrice",
-			"action":        "result",
-			"url":           api["url"],
-			"base":          base,
-			"target":        target,
-			"pair":          pair.Id,
-			"token0_symbol": pair.Token0.Symbol,
-			"token1_symbol": pair.Token1.Symbol,
-			"token0_id":     pair.Token0.Id,
-			"token1_id":     pair.Token1.Id,
-			"token_0_price": pair.Token0Price,
-			"token_1_price": pair.Token1Price,
-			"price":         price,
-		}).Debug()
-
-		return price
-	}
-
-	return ""
-}
-
-func (o *OOOApi) getKnownPairPrice(pairAddress string, api map[string]string) GraphQlPairContent {
-	o.logger.WithFields(logrus.Fields{
-		"package":      "ooo_api",
-		"function":     "getKnownPairPrice",
-		"dex":          api["name"],
-		"url":          api["url"],
-		"pair_address": pairAddress,
-	}).Debug()
-
-	query := generateKnownPairQuery(pairAddress, api["pair_endpoint"], api["pairs_order_by"])
-
-	var decodedResponse GraphQlPairResponse
-
-	o.runQuery(query, api["url"], &decodedResponse)
-
-	// todo - betterize
-	if api["name"] == "uniswapv3" {
-		return decodedResponse.Data.Pool
-	}
-	return decodedResponse.Data.Pair
-}
-
-func (o *OOOApi) getNewPairPrice(t0 string, t1 string, base string, target string, api map[string]string) (GraphQlPairContent, bool) {
-
-	o.logger.WithFields(logrus.Fields{
-		"package":  "ooo_api",
-		"function": "getNewPairPrice",
-		"dex":      api["name"],
-		"url":      api["url"],
-		"t0":       t0,
-		"t1":       t1,
-		"base":     base,
-		"target":   target,
-	}).Debug()
-
-	query := generateNewPairQuery(t0, t1, api["pairs_endpoint"], api["pairs_order_by"])
-
-	var decodedResponse GraphQlPairsResponse
-
-	o.runQuery(query, api["url"], &decodedResponse)
-
-	if len(decodedResponse.Data.Pairs) == 0 && len(decodedResponse.Data.Pools) == 0 {
 		o.logger.WithFields(logrus.Fields{
 			"package":  "ooo_api",
-			"function": "getNewPairPrice",
+			"function": "getPairPricesFromDex",
 			"dex":      api["name"],
 			"url":      api["url"],
 			"base":     base,
 			"target":   target,
-		}).Warn("pair not found")
-		return GraphQlPairContent{}, false
+		}).Error("pair not found in database")
 	}
 
-	if len(decodedResponse.Data.Pairs) > 0 {
-		return decodedResponse.Data.Pairs[0], true
-	}
-
-	if len(decodedResponse.Data.Pools) > 0 {
-		return decodedResponse.Data.Pools[0], true
-	}
-
-	return GraphQlPairContent{}, false
+	return prices
 }
 
-// getToken will attempt to get the token address for a symbol
-func (o *OOOApi) getToken(api map[string]string, symbol string) string {
-
+func (o *OOOApi) getRecentPairPrices(pairAddress string, api map[string]string, currentBlock uint64) GraphQlAliasedPairPrices {
 	o.logger.WithFields(logrus.Fields{
-		"package":  "ooo_api",
-		"function": "getToken",
-		"dex":      api["name"],
-		"url":      api["url"],
-		"symbol":   symbol,
+		"package":       "ooo_api",
+		"function":      "getKnownPairPrice",
+		"dex":           api["name"],
+		"url":           api["url"],
+		"pair_address":  pairAddress,
+		"current_block": currentBlock,
 	}).Debug()
 
-	query := generateTokenQuery(symbol, api["tokens_endpoint"], api["token_order_by"])
+	blocksPerMin, err := strconv.Atoi(api["blocks_in_one_min"])
+	if err != nil {
+		blocksPerMin = 10
+	}
 
-	var decodedResponse GraphQlTokenResponse
+	query := generatePairPricesQuery(pairAddress, api["pair_endpoint"], api["pairs_order_by"], uint64(blocksPerMin), currentBlock)
+
+	var decodedResponse GraphQlPairPricesResponse
 
 	o.runQuery(query, api["url"], &decodedResponse)
 
-	if len(decodedResponse.Data.Tokens) == 0 {
-		o.logger.WithFields(logrus.Fields{
-			"package":  "ooo_api",
-			"function": "getToken",
-			"dex":      api["name"],
-			"url":      api["url"],
-			"symbol":   symbol,
-		}).Warn("token not found")
-		return ""
-	}
+	return decodedResponse.Data
 
-	return decodedResponse.Data.Tokens[0].Id
 }
 
 // runQuery will run the subgraph query
@@ -453,6 +465,61 @@ func generateTokenQuery(symbol string, tokensEndpoint string, tokenOrderBy strin
 	return jsonData
 }
 
+func generatePairsListQuery(pairEndpoint, pairOrderBy, txCount string, skip uint64) map[string]string {
+
+	txCountFilter := ""
+	if txCount != "" {
+		txCountFilter = fmt.Sprintf(`txCount_gt: "%d"`, MIN_TX_COUNT)
+	}
+	skipFilter := ""
+	if skip > 0 {
+		skipFilter = fmt.Sprintf(`skip: %d,`, skip)
+	}
+
+	jsonData := map[string]string{
+		"query": fmt.Sprintf(`
+            {
+	            %s(
+	                first: 1000,
+                    %s
+	                orderBy: %s,
+	                orderDirection: desc,
+                    where :
+                     {
+                          %s_gt: "%d",
+                          %s
+                     }
+	            ) 
+                {
+                     id
+	                 %s
+	                 volumeUSD
+	                 %s
+	                 untrackedVolumeUSD
+	                 token0Price
+	                 token1Price
+	                 __typename
+                     token0 {
+	                     id
+	                     symbol
+	                     name
+	                     decimals
+	                     __typename
+	                 }
+	                 token1 {
+	                     id
+                         symbol 
+                         name 
+                         decimals
+                         __typename
+	                 }
+	            }
+	        }`, pairEndpoint, skipFilter, pairOrderBy, pairOrderBy, MIN_LIQUIDITY, txCountFilter, pairOrderBy, txCount),
+	}
+
+	return jsonData
+}
+
 // generateNewPairQuery uses a fuzzy token query to get the top pair by txCount
 func generateNewPairQuery(t0 string, t1 string, pairEndpoint string, pairOrderBy string) map[string]string {
 	jsonData := map[string]string{
@@ -513,6 +580,84 @@ func generateKnownPairQuery(pairAddress string, pairEndpoint string, pairOrderBy
                 }
 	        }
         `, pairEndpoint, pairAddress, pairOrderBy),
+	}
+
+	return jsonData
+}
+
+func generatePairPricesQuery(pairAddress string, pairEndpoint string, pairOrderBy string, blocksPerMin, currentBlock uint64) map[string]string {
+
+	baseQuery := fmt.Sprintf(`
+id
+	                token0 {
+                         id
+                         name
+                         symbol
+                    }
+                    token1 {
+                         id
+                         name
+                         symbol
+                    }
+                    token0Price
+                    token1Price
+                    %s`, pairOrderBy)
+
+	p0Q := fmt.Sprintf(`%s(id: "%s") {
+                     %s
+                }`, pairEndpoint, pairAddress, baseQuery)
+
+	p1Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-blocksPerMin, baseQuery)
+
+	p2Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*2), baseQuery)
+
+	p3Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*3), baseQuery)
+
+	p4Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*4), baseQuery)
+
+	p5Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*5), baseQuery)
+
+	p6Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*6), baseQuery)
+
+	p7Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*7), baseQuery)
+
+	p8Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*8), baseQuery)
+
+	p9Q := fmt.Sprintf(`%s(id: "%s", block: { number: %d }) {
+                     %s
+                }`, pairEndpoint, pairAddress, currentBlock-(blocksPerMin*9), baseQuery)
+
+	jsonData := map[string]string{
+		"query": fmt.Sprintf(`
+            {
+	            p0: %s,
+                p1: %s,
+                p2: %s,
+                p3: %s,
+                p4: %s,
+                p5: %s,
+                p6: %s,
+                p7: %s,
+                p8: %s,
+                p9: %s
+	        }
+        `, p0Q, p1Q, p2Q, p3Q, p4Q, p5Q, p6Q, p7Q, p8Q, p9Q),
 	}
 
 	return jsonData

--- a/go-ooo/ooo_api/api.go
+++ b/go-ooo/ooo_api/api.go
@@ -30,6 +30,7 @@ type OOOApi struct {
 	subchainEthClient     *ethclient.Client
 	subchainPolygonClient *ethclient.Client
 	subchainBscClient     *ethclient.Client
+	subchainXdaiClient    *ethclient.Client
 }
 
 func NewApi(ctx context.Context, db *database.DB, logger *logrus.Logger) (*OOOApi, error) {
@@ -52,6 +53,12 @@ func NewApi(ctx context.Context, db *database.DB, logger *logrus.Logger) (*OOOAp
 		return nil, err
 	}
 
+	subchainXdaiClient, err := ethclient.Dial(viper.GetString(config.SubChainXdaiHttpRpc))
+
+	if err != nil {
+		return nil, err
+	}
+
 	return &OOOApi{
 		baseURL: viper.GetString(config.JobsOooApiUrl),
 		client: &http.Client{
@@ -63,6 +70,7 @@ func NewApi(ctx context.Context, db *database.DB, logger *logrus.Logger) (*OOOAp
 		subchainEthClient:     subchainEthClient,
 		subchainPolygonClient: subchainPolygonClient,
 		subchainBscClient:     subchainBscClient,
+		subchainXdaiClient:    subchainXdaiClient,
 	}, nil
 }
 

--- a/go-ooo/ooo_api/types.go
+++ b/go-ooo/ooo_api/types.go
@@ -1,0 +1,81 @@
+package ooo_api
+
+type OoOAPIPairsResult struct {
+	Name   string
+	Base   string
+	Target string
+}
+
+type OoOAPIPriceQueryResult struct {
+	Base          string  `json:"base"`
+	Target        string  `json:"target"`
+	Pair          string  `json:"pair"`
+	Time          string  `json:"time,omitempty"`
+	OutlierMethod string  `json:"outlierMethod,omitempty"`
+	Price         string  `json:"price"`
+	PriceRaw      float64 `json:"priceRaw,omitempty"`
+	Dmax          uint64  `json:"dMax,omitempty"`
+}
+
+type GraphQlToken struct {
+	Id             string `json:"id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Symbol         string `json:"symbol,omitempty"`
+	TotalLiquidity string `json:"totalLiquidity,omitempty"`
+	TxCount        string `json:"txCount,omitempty"`
+	Typename       string `json:"__typename,omitempty"`
+}
+type GraphQlTokens struct {
+	Tokens []GraphQlToken
+}
+type GraphQlTokenResponse struct {
+	Data GraphQlTokens
+}
+
+type GraphQlPairContent struct {
+	Id                  string
+	Token0              GraphQlToken
+	Token1              GraphQlToken
+	Token0Price         string `json:"token0Price"`
+	Token1Price         string `json:"token1Price"`
+	ReserveUSD          string `json:"reserveUSD,omitempty"`
+	VolumeUSD           string `json:"volumeUSD,omitempty"`
+	TotalValueLockedUSD string `json:"totalValueLockedUSD,omitempty"`
+	TxCount             string `json:"txCount,omitempty"`
+	Typename            string `json:"__typename,omitempty"`
+	UntrackedVolumeUSD  string `json:"untrackedVolumeUSD,omitempty"`
+}
+
+type GraphQlAliasedPairPrices struct {
+	P0 GraphQlPairContent `json:"p0,omitempty"`
+	P1 GraphQlPairContent `json:"p1,omitempty"`
+	P2 GraphQlPairContent `json:"p2,omitempty"`
+	P3 GraphQlPairContent `json:"p3,omitempty"`
+	P4 GraphQlPairContent `json:"p4,omitempty"`
+	P5 GraphQlPairContent `json:"p5,omitempty"`
+	P6 GraphQlPairContent `json:"p6,omitempty"`
+	P7 GraphQlPairContent `json:"p7,omitempty"`
+	P8 GraphQlPairContent `json:"p8,omitempty"`
+	P9 GraphQlPairContent `json:"p9,omitempty"`
+}
+
+type GraphQlPairPricesResponse struct {
+	Data GraphQlAliasedPairPrices
+}
+
+type GraphQlPairs struct {
+	Pairs []GraphQlPairContent `json:"pairs,omitempty"`
+	Pools []GraphQlPairContent `json:"pools,omitempty"`
+}
+
+type GraphQlPairsResponse struct {
+	Data GraphQlPairs
+}
+
+type GraphQlPair struct {
+	Pair GraphQlPairContent `json:"pair,omitempty"`
+	Pool GraphQlPairContent `json:"pool,omitempty"`
+}
+type GraphQlPairResponse struct {
+	Data GraphQlPair
+}

--- a/go-ooo/types/types.go
+++ b/go-ooo/types/types.go
@@ -81,23 +81,6 @@ type AnalyticsTaskResponse struct {
 	Result  AnalyticsResult
 }
 
-type OoOAPIPairsResult struct {
-	Name   string
-	Base   string
-	Target string
-}
-
-type OoOAPIPriceQueryResult struct {
-	Base          string  `json:"base"`
-	Target        string  `json:"target"`
-	Pair          string  `json:"pair"`
-	Time          string  `json:"time,omitempty"`
-	OutlierMethod string  `json:"outlierMethod,omitempty"`
-	Price         string  `json:"price"`
-	PriceRaw      float64 `json:"priceRaw,omitempty"`
-	Dmax          uint64  `json:"dMax,omitempty"`
-}
-
 type Prices struct {
 	Eth float64 `json:"eth"`
 	Usd float64 `json:"usd"`


### PR DESCRIPTION
Improvements to the AdHoc query processing and implementation:

- Oracle will periodically poll known DEXs for pair data. Token, pair/pool and reserveUSD data is stored locally in the Oracle's database for faster lookups when processing AdHoc queries
- on receiving an AdHoc request, Oracle will query the known DEXs for pair price data, if the pair is supported on the DEX
- Oracle will grab 10 minutes' worth of historical price data along with the current price from each DEX for requested AdHoc pair
- price data from all DEXs is aggregated, and analysed. Chauvenet Criterion is applied to remove statistical outliers if the dataset's standard deviation is > 0, prior to calculating the mean price for return to the requesting smart contract. This helps reduce inaccurate mean price calculations due to potential price manipulation